### PR TITLE
build: don't run lint from test-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ test-all-http1: test-build
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
+test-ci:
+	$(PYTHON) tools/test.py -ptap --logfile test.tap --mode=release --arch=$(DESTCPU) simple message internet
+
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release
 
@@ -417,11 +420,6 @@ bench-idle:
 	./node benchmark/idle_server.js &
 	sleep 1
 	./node benchmark/idle_clients.js &
-
-test-ci:
-	$(PYTHON) tools/test.py -ptap --logfile test.tap --mode=release --arch=$(DESTCPU) simple message internet
-	$(MAKE) jslint
-	$(MAKE) cpplint
 
 jslintfix:
 	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js


### PR DESCRIPTION
Since we will run linting before compiling or testing there's no
need to run it as part of the ci testing.

Cherry-picked from https://github.com/nodejs/io.js/commit/8d8a26e8f7b4e65191af80d94bccada2217cbbb2
Original commit metadata follows:
  PR-URL: https://github.com/nodejs/io.js/pull/1965
  Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
  Revewied-By: Evan Lucas <evanlucas@me.com>